### PR TITLE
change result textarea from disabled to readonly to enable selection

### DIFF
--- a/result.php
+++ b/result.php
@@ -46,7 +46,7 @@
 
       <div class="form-group">
         <label for="json">JSON</label>
-        <textarea id="json" name="json" rows="24" class="form-control form-control-lg" disabled="disabled"><?= htmlspecialchars($json) ?></textarea>
+        <textarea id="json" name="json" rows="24" class="form-control form-control-lg" readonly><?= htmlspecialchars($json) ?></textarea>
       </div>
 
       <button type="submit" class="btn btn-lg btn-success">Parse</button>


### PR DESCRIPTION
Setting a textarea as `disabled` means the user can not select text. Using `readonly` instead allows selecting (and copying!), but still protects the content from being changed.