### PR TITLE
Use p3k/http instead of manual cURL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "mf2/mf2": ">=0.4.5",
     "predis/predis": "^1.1",
     "ext-mbstring": "*",
-    "masterminds/html5": "^2.3"
+    "masterminds/html5": "^2.3",
+    "p3k/http": "^0.1.11"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,57 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b30ac7b992bb08f0fc19801efd9b1c6b",
+    "content-hash": "0e295753b0a789d68707fd5ad3fadd77",
     "packages": [
+        {
+            "name": "indieweb/link-rel-parser",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/indieweb/link-rel-parser-php.git",
+                "reference": "295420e4f16d9a9d262a3c25a7a583794428f055"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/indieweb/link-rel-parser-php/zipball/295420e4f16d9a9d262a3c25a7a583794428f055",
+                "reference": "295420e4f16d9a9d262a3c25a7a583794428f055",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/IndieWeb/link_rel_parser.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Parecki",
+                    "homepage": "http://aaronparecki.com"
+                },
+                {
+                    "name": "Tantek Çelik",
+                    "homepage": "http://tantek.com"
+                }
+            ],
+            "description": "Parse rel values from HTTP headers",
+            "homepage": "https://github.com/indieweb/link-rel-parser-php",
+            "keywords": [
+                "http",
+                "indieweb",
+                "microformats2"
+            ],
+            "time": "2017-01-11T17:14:49+00:00"
+        },
         {
             "name": "masterminds/html5",
             "version": "2.3.0",
@@ -128,6 +174,44 @@
             "time": "2018-08-24T14:47:04+00:00"
         },
         {
+            "name": "p3k/http",
+            "version": "0.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aaronpk/p3k-http.git",
+                "reference": "24d28287e0c5606aa45b23c6e3c17628d89468f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aaronpk/p3k-http/zipball/24d28287e0c5606aa45b23c6e3c17628d89468f7",
+                "reference": "24d28287e0c5606aa45b23c6e3c17628d89468f7",
+                "shasum": ""
+            },
+            "require": {
+                "indieweb/link-rel-parser": "0.1.*",
+                "mf2/mf2": ">=0.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "p3k\\": "src/p3k"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Parecki",
+                    "homepage": "https://aaronparecki.com"
+                }
+            ],
+            "description": "A simple wrapper API around the PHP curl functions",
+            "homepage": "https://github.com/aaronpk/p3k-http",
+            "time": "2020-02-19T03:00:09+00:00"
+        },
+        {
             "name": "predis/predis",
             "version": "v1.1.1",
             "source": {
@@ -188,5 +272,6 @@
         "php": ">=5.6.0",
         "ext-mbstring": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/index.php
+++ b/index.php
@@ -53,6 +53,10 @@ if(get('url')) {
       die();
   }
 
+  if ($page['error'] !== '') {
+    $debugMsg = ['error' => [ 'type' => $page['error'], 'description' => $page['error_description'] ]] + $debugMsg;
+  }
+
   $parser = new Parser($page['body'], $page['url'], true);
   $parser->lang = true;
   $output = $parser->parse();

--- a/index.php
+++ b/index.php
@@ -43,31 +43,17 @@ if(get('url')) {
   if(!preg_match('/^http/', $url))
     $url = 'http://' . $url;
 
-  $ch = curl_init();
-  curl_setopt($ch, CURLOPT_URL, $url);
-  #curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36');
-  curl_setopt($ch, CURLOPT_USERAGENT, 'Microformats2 parser '.$version.' (via '.$_SERVER['SERVER_NAME'].$PATH.') Mozilla/5.0 Chrome/29.0.1547.57 Safari/537.36');
-  curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: text/html, */*']);
-  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-  curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+  $client = new p3k\HTTP('Microformats2 parser '.$version.' (via '.$_SERVER['SERVER_NAME'].$PATH.') Mozilla/5.0 Chrome/29.0.1547.57 Safari/537.36');
+  $headers = ['Accept: text/html, */*'];
+  $page = $client->get($url);
 
   if(get('debug')) {
-      curl_setopt($ch, CURLOPT_SSLVERSION,3);
-      $html = curl_exec($ch);
-      echo $html;
-      echo curl_errno($ch);
-      $info = curl_getinfo($ch);
       echo '<pre>';
-      print_r($info);
+      print_r($page);
       die();
-  } else {
-      $html = curl_exec($ch);
   }
 
-  $url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-  $parser = new Parser($html, $url, true);
+  $parser = new Parser($page['body'], $page['url'], true);
   $parser->lang = true;
   $output = $parser->parse();
   $output['debug'] = $debugMsg;


### PR DESCRIPTION
This enables parsing of a couple more weirdly-configured sites, as was [raised on the #indieweb-meta channel yesterday](https://chat.indieweb.org/meta/2020-07-28/1595945414258000).

I am pulling in [p3k/http](https://github.com/aaronpk/p3k-http) here specifically because it is used by a couple other IndieWeb tools, like [XRay](https://github.com/aaronpk/XRay). This means we are more likely to spot errors if they come up, and only need to fix them in 1 location. This sadly leads to one extra dependency that isn’t strictly necessary for the mf2 parsing, but that is much less overhead than if something like a full PSR-18 HTTP Client had been pulled in.

Note that this changes the debug output to render the entire response array from the p3k/http implementation. I do not think we will lose any valuable information (cURL error codes are also in there). Is there any reason to try and match the old debug output more exactly?